### PR TITLE
Update shutdown.c with GNU Affero General Public License v3

### DIFF
--- a/include/alinix/unstar.h
+++ b/include/alinix/unstar.h
@@ -1,0 +1,21 @@
+/**
+ ** This file is part of AliNix.
+
+**AliNix is free software: you can redistribute it and/or modify
+**it under the terms of the GNU Affero General Public License as published by
+**the Free Software Foundation, either version 3 of the License, or
+**(at your option) any later version.
+
+**AliNix is distributed in the hope that it will be useful,
+**but WITHOUT ANY WARRANTY; without even the implied warranty of
+**MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**GNU Affero General Public License for more details.
+
+**You should have received a copy of the GNU Affero General Public License
+**along with AliNix. If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef __ALINIX_KERNEL_UNSTAR_H
+#define __ALINIX_KERNEL_UNSTAR_H
+
+
+#endif /* __ALINIX_KERNEL_UNSTAR_H */

--- a/include/alinix/unstar.h
+++ b/include/alinix/unstar.h
@@ -17,5 +17,9 @@
 #ifndef __ALINIX_KERNEL_UNSTAR_H
 #define __ALINIX_KERNEL_UNSTAR_H
 
+int oct2bin(unsigned char *str, int size);
+
+/*Returns the size and the pointer to the file data*/
+int tar_lookup(unsigned char *archive, char *filename, char **out);
 
 #endif /* __ALINIX_KERNEL_UNSTAR_H */

--- a/kernel/drivers/tar/USTAR/ustar.c
+++ b/kernel/drivers/tar/USTAR/ustar.c
@@ -14,3 +14,7 @@
 **You should have received a copy of the GNU Affero General Public License
 **along with AliNix. If not, see <https://www.gnu.org/licenses/>.
 */
+#include <alinix/init.h>
+#include <alinix/types.h>
+#include <alinix/kernel.h>
+#include <alinix/port.h>

--- a/kernel/drivers/tar/USTAR/ustar.c
+++ b/kernel/drivers/tar/USTAR/ustar.c
@@ -18,3 +18,33 @@
 #include <alinix/types.h>
 #include <alinix/kernel.h>
 #include <alinix/port.h>
+#include <alinix/unstar.h>
+#include <alinix/memory.h>
+#include <alinix/ulib.h>
+#include <alinix/heap.h>
+
+int oct2bin(unsigned char *str, int size){
+    int n = 0;
+    unsigned char *c = str;
+
+    while (size-- > 0){
+        n *= 8;
+        n += *c - '0';
+        c++;
+    }
+    return n;
+}
+
+int tar_lookup(unsigned char *archive, char *filename, char **out){
+    unsigned char *ptr = archive;
+
+    while (!memcmp(ptr + 257 ,"unstar",5)){
+        int fileSize = oct2bin(ptr+0x7c,11);
+        if (!memcmp(ptr, filename, strlen(filename) + 1)) {
+            *out = ptr + 512;
+            return fileSize;
+        }
+        ptr += (((fileSize + 511) / 512) + 1) * 512;
+    }
+    return 0;
+}

--- a/kernel/drivers/tar/USTAR/ustar.c
+++ b/kernel/drivers/tar/USTAR/ustar.c
@@ -35,13 +35,22 @@ int oct2bin(unsigned char *str, int size){
     return n;
 }
 
-int tar_lookup(unsigned char *archive, char *filename, char **out){
-    unsigned char *ptr = archive;
 
-    while (!memcmp(ptr + 257 ,"unstar",5)){
-        int fileSize = oct2bin(ptr+0x7c,11);
+/**
+ * @brief Look up a file in a TAR archive and retrieve its contents.
+ * 
+ * @param archive The TAR archive stored as a byte array.
+ * @param filename The name of the file to search for in the TAR archive.
+ * @param out A pointer to a pointer that will store the contents of the found file.
+ * @return The size of the file if found, 0 otherwise.
+ */
+int tar_lookup(unsigned char *archive, char *filename, char **out){
+    unsigned char *ptr = archive; // Set pointer to the start of the archive
+
+    while (!memcmp(ptr + 257 ,"ustar",5)) { // Check for valid ustar header
+        int fileSize = oct2bin(ptr+0x7c,11); // Get file size from the header
         if (!memcmp(ptr, filename, strlen(filename) + 1)) {
-            *out = ptr + 512;
+            *out = ptr + 512; // Set the pointer to start of file
             return fileSize;
         }
         ptr += (((fileSize + 511) / 512) + 1) * 512;

--- a/kernel/drivers/tar/USTAR/ustar.c
+++ b/kernel/drivers/tar/USTAR/ustar.c
@@ -14,20 +14,3 @@
 **You should have received a copy of the GNU Affero General Public License
 **along with AliNix. If not, see <https://www.gnu.org/licenses/>.
 */
-#include <alinix/shutdown.h>
-#include <alinix/init.h>
-#include <alinix/kernel.h>
-
-
-/**
- * @ref https://wiki.osdev.org/Shutdown
-*/
-
-/**
- * @brief Function that administrate the shutdown proccess
- * @param None
-*/
-void shutdown(){
-    outportw(0x604, 0x2000);
-    // This is mostly used in QEMU
-}


### PR DESCRIPTION
The file shutdown.c has been updated to include the GNU Affero General Public License version 3 (AGPLv3) header. The header states that the